### PR TITLE
docs(readme): Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Similarly to template literals, extended numeric literals desugar into passing a
 
 Example:
 
-`3~px` desugars into `numeric__px(Object.freeze({number: 3, string, "3"}))`
+`3~px` desugars into `numeric__px(Object.freeze({number: 3, string: "3"}))`
 
 ### Caching
 


### PR DESCRIPTION
This corrects:
```js
numeric__px(Object.freeze({number: 3, string, "3"}))
//                                          ^
```
to
```js
numeric__px(Object.freeze({number: 3, string: "3"}))
//                                          ^
```
---

Turns out, this isn’t the first time this has happened: https://github.com/tc39/proposal-extended-numeric-literals/pull/10 🤦🏻‍♂️